### PR TITLE
Replace HTML4 anchor tags with ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
             </nav>
         </div>
 
-        <a name="about"></a>
-        <div class="container">
+        <div id="about" class="container">
             <h2 class="title centered">About</h2>
             <hr class="header-underline" />
             <div class="content">
@@ -51,8 +50,7 @@
             </div>
         </div>
 
-        <a name="qualifications"></a>
-        <div class="container">
+        <div id="qualifications" class="container">
             <h2 class="title centered">Qualifications</h2>
             <hr class="header-underline" />
             <div class="content">
@@ -74,8 +72,7 @@
             </div>
         </div>
 
-        <a name="experience"></a>
-        <div class="container">
+        <div id="experience" class="container">
             <h2 class="title centered">Experience</h2>
             <hr class="header-underline" />
             <div class="content">
@@ -99,8 +96,7 @@
             </div>
         </div>
 
-        <a name="activities"></a>
-        <div class="container">
+        <div id="activities" class="container">
             <h2 class="title centered">Activities</h2>
             <hr class="header-underline" />
             <div class="content">
@@ -111,7 +107,7 @@
                     </p>
                 </div>
                 <img class="img-responsive" alt="Open Source Club logo" src="img/osu_osc.jpeg" />
-                <div class="text-content">
+                <div id="projects" class="text-content">
                     <h3>Projects</h3>
                     <p>
                         My most actively maintained projects are <a href="https://j3rn.com/goe">Game of Evolution</a>, a genetic algorithm written in vanilla JavaScript; <a href="https://github.com/j3rn/minecraft-manager">Minecraft Manager</a>, a Ruby on Rails app to provision, image, and destroy DigitalOcean droplets; and <a href="https://github.com/J3RN/time-tracker">Time Tracker</a>, a Ruby on Rails app to help me manage my todo list.


### PR DESCRIPTION
Apparently in HTML5 the proper way to accomplish the same thing is to reference the DOM element ID in the href field of the anchor tag linking to the element.